### PR TITLE
Add date format to the documentation

### DIFF
--- a/exchangerates/templates/index.html
+++ b/exchangerates/templates/index.html
@@ -136,7 +136,7 @@ GET https://api.exchangeratesapi.io/latest HTTP/1.1
           </pre>
 
           <p>
-            Get historical rates for any day since 1999.
+            Get historical rates for any day since 1999, using <pre>yyyy-mm-dd</pre> format when querying.
           </p>
           <pre>
             <code class="http px-5 rounded-corners">


### PR DESCRIPTION
The examples could be interpreted as either yyyy-mm-dd or yyyy-dd-mm